### PR TITLE
docs: update for new new extension listing guidelines/fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,22 @@
 {
   "name": "codecov",
   "publisher": "sourcegraph",
-  "title": "Codecov",
   "description": "Shows code coverage from Codecov",
   "icon": "https://user-images.githubusercontent.com/1387653/45938068-4daf0b00-bf7b-11e8-9c38-3619d61af834.png",
   "repository": {
     "type": "git",
     "url": "https://github.com/codecov/sourcegraph-codecov.git"
   },
+  "categories": [
+    "External services",
+    "Reports and stats"
+  ],
+  "tags": [
+    "codecov",
+    "coverage",
+    "code coverage",
+    "testing"
+  ],
   "version": "0.0.0-development",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Updates to reflect the changes to extension listings on the extension registry in https://github.com/sourcegraph/sourcegraph/pull/1612 and https://github.com/sourcegraph/sourcegraph/pull/1613:

- Extensions can have tags and categories.
- Extensions no longer have titles. The extension ID and the extension description are the only things shown now.
- The extension description can/should be shorter now that it's shown on 1 line and there is no title.

https://github.com/sourcegraph/sourcegraph/issues/1906