### PR TITLE
Hosted codecov enterprise implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "codecov",
+  "name": "WIP-codecov-uri-fix",
   "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,
@@ -2161,6 +2161,12 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
+    "@sindresorhus/is": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
+      "dev": true
+    },
     "@types/mocha": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
@@ -2253,6 +2259,27 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
@@ -2841,6 +2868,22 @@
       "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      }
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -3547,6 +3590,15 @@
         }
       }
     },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -3670,6 +3722,20 @@
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
+    },
+    "del": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+      "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+      "dev": true,
+      "requires": {
+        "globby": "^6.1.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "p-map": "^1.1.1",
+        "pify": "^3.0.0",
+        "rimraf": "^2.2.8"
+      }
     },
     "depd": {
       "version": "1.1.2",
@@ -4167,6 +4233,16 @@
         }
       }
     },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
     "flatten": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
@@ -4247,14 +4323,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4274,8 +4348,7 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -4423,7 +4496,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4760,6 +4832,12 @@
       "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
       "dev": true
     },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -4812,6 +4890,27 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
       "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
       "dev": true
+    },
+    "globby": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+      "dev": true,
+      "requires": {
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
     },
     "graceful-fs": {
       "version": "4.1.15",
@@ -4939,6 +5038,12 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
     },
     "hsl-regex": {
       "version": "1.0.0",
@@ -5459,6 +5564,15 @@
         "resolve-from": "^3.0.0"
       }
     },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
     "indexes-of": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
@@ -5549,6 +5663,15 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^1.0.0"
+      }
+    },
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
@@ -5632,6 +5755,15 @@
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
     "is-glob": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
@@ -5666,6 +5798,30 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.1"
+      }
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -5719,6 +5875,12 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
     "is-windows": {
@@ -5857,6 +6019,58 @@
         "type-check": "~0.3.2"
       }
     },
+    "lnfs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lnfs/-/lnfs-3.0.1.tgz",
+      "integrity": "sha512-YER0NGDpRS2QcjHTcNdjWG2CTLpUyYt/5LdyXikav4hfZ9QhNvQ2XjDXpahqgcYYA1pi2S4wTbLlAFfZJUp7uw==",
+      "dev": true,
+      "requires": {
+        "del": "^3.0.0",
+        "make-dir": "^1.0.0",
+        "p-series": "^1.0.0",
+        "pify": "^3.0.0"
+      }
+    },
+    "lnfs-cli": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lnfs-cli/-/lnfs-cli-2.1.0.tgz",
+      "integrity": "sha512-9zAI9sjv77IMsB5djIztdh7CUwFPGR5pcQxSPGdnXAV6PsjlHrWspO47xS+zZz6WoUTqSFES1mo4r7xtCPt+Xg==",
+      "dev": true,
+      "requires": {
+        "lnfs": "^3.0.0",
+        "meow": "^3.3.0"
+      }
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
@@ -5905,6 +6119,16 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
     "lru-cache": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.4.tgz",
@@ -5924,6 +6148,15 @@
         "vlq": "^0.2.2"
       }
     },
+    "make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      }
+    },
     "make-error": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
@@ -5934,6 +6167,12 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
     "map-visit": {
@@ -5967,6 +6206,24 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
       "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
       "dev": true
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      }
     },
     "merge-source-map": {
       "version": "1.0.4",
@@ -6056,9 +6313,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
     "mixin-deep": {
@@ -6089,6 +6346,14 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
       }
     },
     "mocha": {
@@ -6245,6 +6510,18 @@
         "osenv": "^0.1.4"
       }
     },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -6279,6 +6556,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+      "dev": true
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "nyc": {
@@ -8515,6 +8798,28 @@
         "os-tmpdir": "^1.0.0"
       }
     },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
+    "p-reduce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+      "dev": true
+    },
+    "p-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-series/-/p-series-1.1.0.tgz",
+      "integrity": "sha512-356covArc9UCfj2twY/sxCJKGMzzO+pJJtucizsPC6aS1xKSTBc9PQrQhvFR3+7F+fa2KBKdJjdIcv6NEWDcIQ==",
+      "dev": true,
+      "requires": {
+        "@sindresorhus/is": "^0.7.0",
+        "p-reduce": "^1.0.0"
+      }
+    },
     "pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -8756,10 +9061,25 @@
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "^2.0.0"
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
@@ -8773,6 +9093,25 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
     },
     "pbkdf2": {
       "version": "3.0.17",
@@ -8792,6 +9131,27 @@
       "resolved": "https://registry.npmjs.org/physical-cpu-count/-/physical-cpu-count-2.0.0.tgz",
       "integrity": "sha1-GN4vl+S/epVRrXURlCtUlverpmA=",
       "dev": true
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -10327,6 +10687,27 @@
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
       "dev": true
     },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      }
+    },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -10351,6 +10732,16 @@
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "reduce-css-calc": {
@@ -10484,6 +10875,15 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
+    },
     "resolve": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
@@ -10532,6 +10932,31 @@
       "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
       "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
     },
     "ripemd160": {
       "version": "2.0.2",
@@ -10900,6 +11325,38 @@
       "integrity": "sha512-mGoCuJngYCT2DOiHLY9/JQrg2Me73dpgtLUlCYOTZjhYg8g0B4XRmde1RLIX+Geb5WM1/0d5IlyV1gVfCe5aYw==",
       "dev": true
     },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+      "dev": true
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -11038,6 +11495,24 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         }
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1"
       }
     },
     "stylehacks": {
@@ -11228,6 +11703,12 @@
       "integrity": "sha512-2Ulkc8T7mXJ2l0W476YC/A209PR38Nw8PuaCNtk9uI3t1zzFdGQeWYGQvmj2PZkVvRC/Yoi4xQKMRnWc/N29tQ==",
       "dev": true
     },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -11324,9 +11805,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
-      "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
+      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -11526,6 +12007,16 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz",
       "integrity": "sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw==",
       "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
     },
     "vendors": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -206,7 +206,13 @@
               },
               "type": {
                 "description": "Define hosted version control type (gh|ghe|bb|gl):",
-                "type": "string"
+                "type": "string",
+                "enum": [
+                  "gh",
+                  "ghe",
+                  "bb",
+                  "gl"
+                ]
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
               },
               "type": {
                 "description": "Define hosted version control type (gh|ghe|bb|gl):",
-                "type": "enum"
+                "type": "string"
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -98,6 +98,12 @@
         "category": "Codecov"
       },
       {
+        "id": "codecov.setupEnterprise",
+        "command": "codecov.setupEnterprise",
+        "title": "Set up Codecov Enterprise",
+        "category": "Codecov"
+      },
+      {
         "id": "codecov.help",
         "command": "open",
         "commandArguments": [
@@ -143,6 +149,9 @@
         },
         {
           "action": "codecov.setAPIToken"
+        },
+        {
+          "action": "codecov.setupEnterprise"
         },
         {
           "action": "codecov.help"
@@ -193,6 +202,10 @@
               },
               "token": {
                 "description": "The Codecov API token for this endpoint (required for private repositories).",
+                "type": "string"
+              },
+              "type": {
+                "description": "Define hosted version control type (gh|ghe|bb|gl):",
                 "type": "string"
               }
             }
@@ -248,7 +261,7 @@
     "ts-node": "^7.0.0",
     "tslint": "^5.10.0",
     "tslint-language-service": "^0.9.9",
-    "typescript": "^3.0.3"
+    "typescript": "^3.2.2"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
               },
               "type": {
                 "description": "Define hosted version control type (gh|ghe|bb|gl):",
-                "type": "string"
+                "type": "enum"
               }
             }
           }

--- a/src/api.ts
+++ b/src/api.ts
@@ -7,7 +7,7 @@ export interface CodecovGetCommitCoverageArgs {
     baseURL: string
 
     /** The identifier for the service where the repository lives. */
-    service: 'gh' | string
+    service: 'gh' | 'gl' | 'bb' | string
 
     /** The value for the :owner URL parameter (the repository's owner). */
     owner: string
@@ -57,7 +57,7 @@ export interface CodecovCommitData {
     }
     owner: {
         /** An identifier for the code host or other service where the repository lives. */
-        service: 'github' | string
+        service: 'github' | 'gitlab' | 'bitbucket'
 
         /** For GitHub, the name of the repository's owner. */
         username: string

--- a/src/api.ts
+++ b/src/api.ts
@@ -7,7 +7,7 @@ export interface CodecovGetCommitCoverageArgs {
     baseURL: string
 
     /** The identifier for the service where the repository lives. */
-    service: 'gh' | 'gl' | 'bb' | string
+    service: 'gh' | 'gl' | 'bb' | 'ghe'
 
     /** The value for the :owner URL parameter (the repository's owner). */
     owner: string

--- a/src/api.ts
+++ b/src/api.ts
@@ -7,7 +7,7 @@ export interface CodecovGetCommitCoverageArgs {
     baseURL: string
 
     /** The identifier for the service where the repository lives. */
-    service: 'gh' | 'gl' | 'bb' | 'ghe'
+    service: string
 
     /** The value for the :owner URL parameter (the repository's owner). */
     owner: string

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { Settings, resolveSettings, resolveEndpoint } from './settings'
+import { Settings, resolveSettings, resolveEndpoint, Location, Endpoint } from './settings'
 import * as sourcegraph from 'sourcegraph'
 import {
     getFileCoverageRatios,
@@ -71,8 +71,7 @@ export function activate(): void {
         } = {}
 
         const p = codecovParamsForRepositoryCommit(lastURI)
-        // TODO Support non-codecov.io endpoints.
-        const repoURL = `https://codecov.io/${p.service}/${p.owner}/${p.repo}`
+        const repoURL = `${p.baseURL || 'https://codecov.io'}/${p.service}/${p.owner}/${p.repo}`
         context['codecov.repoURL'] = repoURL
         const baseFileURL = `${repoURL}/src/${p.sha}`
         context['codecov.commitURL'] = `${repoURL}/commit/${p.sha}`
@@ -106,27 +105,61 @@ export function activate(): void {
         sourcegraph.workspace.onDidChangeRoots.subscribe(() => updateContext())
     }
 
+
+    sourcegraph.commands.registerCommand('codecov.setupEnterprise', async () => {
+        const endpoint = resolveEndpoint(
+            sourcegraph.configuration.get<Settings>().get('codecov.endpoints')
+        )
+        if (!sourcegraph.app.activeWindow) {
+            throw new Error(
+                'To set a Codecov Endpoint, navigate to a file and then re-run this command.'
+            )
+        }
+
+        const service = await sourcegraph.app.activeWindow.showInputBox({
+            prompt: `Version control type (gh/ghe/bb/gl):`,
+            value: endpoint.service || '',
+        })
+
+        const url = await sourcegraph.app.activeWindow.showInputBox({
+            prompt: `Codecov endpoint:`,
+            value: endpoint.url || '',
+        })
+
+        if (url !== undefined && service !== undefined) {
+            // TODO: Only supports setting the token of the first API endpoint.
+            return sourcegraph.configuration
+                .get<Settings>()
+                .update('codecov.endpoints', [
+                    { ...endpoint, url, service },
+                ])
+        }
+    })
+
     // Handle the "Set Codecov API token" command (show the user a prompt for their token, and save
     // their input to settings).
     sourcegraph.commands.registerCommand('codecov.setAPIToken', async () => {
         const endpoint = resolveEndpoint(
             sourcegraph.configuration.get<Settings>().get('codecov.endpoints')
         )
+
         if (!sourcegraph.app.activeWindow) {
             throw new Error(
                 'To set a Codecov API token, navigate to a file and then re-run this command.'
             )
         }
+
         const token = await sourcegraph.app.activeWindow.showInputBox({
             prompt: `Codecov API token (for ${endpoint.url}):`,
-            value: endpoint.token || '',
+            value: endpoint.token || undefined,
         })
+
         if (token !== undefined) {
             // TODO: Only supports setting the token of the first API endpoint.
             return sourcegraph.configuration
                 .get<Settings>()
                 .update('codecov.endpoints', [
-                    { ...endpoint, token: token || undefined },
+                    { ...endpoint, token },
                 ])
         }
     })

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { Settings, resolveSettings, resolveEndpoint, Location, Endpoint } from './settings'
+import { Settings, resolveSettings, resolveEndpoint, Location, Endpoint, Service } from './settings'
 import * as sourcegraph from 'sourcegraph'
 import {
     getFileCoverageRatios,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -21,14 +21,16 @@ export function resolveSettings(raw: Partial<Settings>): Settings {
         ['codecov.decorations.lineHitCounts']: !!raw[
             'codecov.decorations.lineHitCounts'
         ],
-        ['codecov.endpoints']: [resolveEndpoint(raw['codecov.endpoints'])],
+        ['codecov.endpoints']: [resolveEndpoint(raw['codecov.endpoints'])]
     }
 }
 
 export interface Endpoint {
-    url: string
+    url?: string
     token?: string
+    service?: string
 }
+
 
 const CODECOV_IO_URL = 'https://codecov.io'
 
@@ -48,6 +50,7 @@ export function resolveEndpoint(
             ? urlWithOnlyProtocolAndHost(endpoints[0].url)
             : CODECOV_IO_URL,
         token: endpoints[0].token || undefined,
+        service: endpoints[0].service || undefined
     }
 }
 

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -24,6 +24,11 @@ export function resolveURI(uri: string): ResolvedURI {
     }
 }
 
+export interface KnownHost {
+    name: string;
+    service: string;
+}
+
 /**
  * Returns the URL parameters used to access the Codecov API for the URI's repository.
  *
@@ -36,14 +41,14 @@ export function codecovParamsForRepositoryCommit(
         const endpoints: Endpoint[] | undefined = sourcegraph.configuration.get<Settings>().get('codecov.endpoints')
         const baseURL: string = endpoints && endpoints[0] && endpoints[0].url || ''
 
-        const knownHosts: { name: string, service: string }[] = [
+        const knownHosts: KnownHost[] = [
             { name: 'github.com', service: 'gh' },
             { name: 'gitlab.com', service: 'gl' },
             { name: 'bitbucket.org', service: 'bb' },
         ];
 
 
-        const knownHost: any = knownHosts.find(knownHost => uri.repo.includes(knownHost.name))
+        const knownHost: KnownHost | undefined = knownHosts.find(knownHost => uri.repo.includes(knownHost.name))
 
         let service: string = endpoints && endpoints[0] && endpoints[0].service || 'gh'
 

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -45,7 +45,7 @@ export function codecovParamsForRepositoryCommit(
 
         const knownHost: any = knownHosts.find(knownHost => uri.repo.includes(knownHost.name))
 
-        let service = endpoints && endpoints[0] && endpoints[0].service || 'gh'
+        let service: string = endpoints && endpoints[0] && endpoints[0].service || 'gh'
 
         const [, owner, repo] = uri.repo.split('/', 4)
 

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -1,4 +1,6 @@
+import * as sourcegraph from 'sourcegraph'
 import { CodecovGetCommitCoverageArgs } from './api'
+import { Settings, Endpoint } from './settings';
 
 /**
  * A resolved URI identifies a path in a repository at a specific revision.
@@ -15,16 +17,11 @@ export interface ResolvedURI {
  */
 export function resolveURI(uri: string): ResolvedURI {
     const url = new URL(uri)
-    if (url.protocol === 'git:') {
-        return {
-            repo: (url.host + url.pathname).replace(/^\/*/, '').toLowerCase(),
-            rev: url.search.slice(1).toLowerCase(),
-            path: url.hash.slice(1),
-        }
+    return {
+        repo: (url.host + url.pathname).replace(/^\/*/, '').toLowerCase(),
+        rev: url.search.slice(1).toLowerCase(),
+        path: url.hash.slice(1),
     }
-    throw new Error(
-        `unrecognized URI: ${JSON.stringify(uri)} (supported URI schemes: git)`
-    )
 }
 
 /**
@@ -34,27 +31,45 @@ export function resolveURI(uri: string): ResolvedURI {
  */
 export function codecovParamsForRepositoryCommit(
     uri: Pick<ResolvedURI, 'repo' | 'rev'>
-): Pick<CodecovGetCommitCoverageArgs, 'service' | 'owner' | 'repo' | 'sha'> {
-    // TODO: Support services (code hosts) other than GitHub.com, such as GitHub Enterprise, GitLab, etc.
-    if (uri.repo.startsWith('github.com/')) {
+): Pick<CodecovGetCommitCoverageArgs, 'baseURL' | 'service' | 'owner' | 'repo' | 'sha'> {
+    try {
+        const endpoints: Endpoint[] | undefined = sourcegraph.configuration.get<Settings>().get('codecov.endpoints')
+        const baseURL: string = endpoints && endpoints[0] && endpoints[0].url || ''
+
+        const knownHosts: any[] = [
+            { name: 'github.com', service: 'gh' },
+            { name: 'gitlab.com', service: 'gl' },
+            { name: 'bitbucket.org', service: 'bb' },
+        ];
+
+        const knownHost: any = knownHosts.find((knownHost: any) => {
+            if (uri.repo.includes(knownHost.name)) {
+                return knownHost;
+            }
+        });
+
+        let service = endpoints && endpoints[0] && endpoints[0].service || 'gh'
+
         const parts = uri.repo.split('/', 4)
-        if (parts.length !== 3) {
-            throw new Error(
-                `invalid GitHub.com repository: ${JSON.stringify(
-                    uri.repo
-                )} (expected "github.com/owner/repo")`
-            )
-        }
+
+        const owner = parts[1];
+        const repo = parts[2];
+
+        service = knownHost && knownHost.service || service;
+
         return {
-            service: 'gh',
-            owner: parts[1],
-            repo: parts[2],
+            baseURL,
+            service,
+            owner,
+            repo,
             sha: uri.rev,
-        }
+        };
+
+    } catch (err) {
+        throw new Error(
+            `extension does not yet support the repository ${JSON.stringify(
+                uri.repo
+            )}`
+        )
     }
-    throw new Error(
-        `extension does not yet support the repository ${JSON.stringify(
-            uri.repo
-        )}`
-    )
 }

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -36,24 +36,18 @@ export function codecovParamsForRepositoryCommit(
         const endpoints: Endpoint[] | undefined = sourcegraph.configuration.get<Settings>().get('codecov.endpoints')
         const baseURL: string = endpoints && endpoints[0] && endpoints[0].url || ''
 
-        const knownHosts: any[] = [
+        const knownHosts: { name: string, service: string }[] = [
             { name: 'github.com', service: 'gh' },
             { name: 'gitlab.com', service: 'gl' },
             { name: 'bitbucket.org', service: 'bb' },
         ];
 
-        const knownHost: any = knownHosts.find((knownHost: any) => {
-            if (uri.repo.includes(knownHost.name)) {
-                return knownHost;
-            }
-        });
+
+        const knownHost: any = knownHosts.find(knownHost => uri.repo.includes(knownHost.name))
 
         let service = endpoints && endpoints[0] && endpoints[0].service || 'gh'
 
-        const parts = uri.repo.split('/', 4)
-
-        const owner = parts[1];
-        const repo = parts[2];
+        const [, owner, repo] = uri.repo.split('/', 4)
 
         service = knownHost && knownHost.service || service;
 


### PR DESCRIPTION
Adds support for running sourcegraph on a hosted source control instance with Codecov Enterprise

- Adds support for fetching codecov data if you're on Bitbucket and Gitlab as well now.

- Adds support for Codecov Enterprise

  There's a new setting for this, which has 2 steps:
  * First you fill out the alias for the type of source control you are currently on (gh/ghe/gl/bb) (this is needed to fetch from the right route on Codecov).
  * Then you fill in the BaseURL to where your Codecov Enterprise instance lives