### PR TITLE
Preserve case in resolveURI

### DIFF
--- a/src/uri.ts
+++ b/src/uri.ts
@@ -18,8 +18,8 @@ export interface ResolvedURI {
 export function resolveURI(uri: string): ResolvedURI {
     const url = new URL(uri)
     return {
-        repo: (url.host + url.pathname).replace(/^\/*/, '').toLowerCase(),
-        rev: url.search.slice(1).toLowerCase(),
+        repo: (url.host + url.pathname).replace(/^\/*/, ''),
+        rev: url.search.slice(1),
         path: url.hash.slice(1),
     }
 }


### PR DESCRIPTION
fixes sourcegraph/sourcegraph#2073, sourcegraph/sourcegraph#1116

`resolveURI()` should not lowercase the repo and rev of a document's URI, otherwise expressions referencing `resource.uri` in contributions may return `undefined`, notably when the repo name is case-sensitive (eg. TakuyaHara/test):

```
get(context, `codecov.coverageRatio.${resource.uri}`)
```