### PR TITLE
Upgrade sourcegraph dependency to 20.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "parcel-bundler": "^1.10.0",
     "prettier": "^1.13.7",
     "source-map-support": "^0.5.6",
-    "sourcegraph": "^19.2.0",
+    "sourcegraph": "^20.1.0",
     "ts-node": "^7.0.0",
     "tslint": "^5.10.0",
     "tslint-language-service": "^0.9.9",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { Settings, resolveSettings, resolveEndpoint, Location, Endpoint, Service } from './settings'
+import { Settings, resolveSettings, resolveEndpoint } from './settings'
 import * as sourcegraph from 'sourcegraph'
 import {
     getFileCoverageRatios,
@@ -7,6 +7,8 @@ import {
 } from './model'
 import { codecovToDecorations } from './decoration'
 import { resolveURI, codecovParamsForRepositoryCommit } from './uri'
+
+const decorationType = sourcegraph.app.createDecorationType && sourcegraph.app.createDecorationType()
 
 /** Entrypoint for the Codecov Sourcegraph extension. */
 export function activate(): void {
@@ -31,7 +33,7 @@ export function activate(): void {
                     settings['codecov.endpoints'][0]
                 )
                 editor.setDecorations(
-                    null,
+                    decorationType,
                     codecovToDecorations(settings, decorations)
                 )
             }


### PR DESCRIPTION
The latest version of the Sourcegraph extension API allows passing a decoration type to `setDecorations`, which avoids conflicts between decorations contributed by different extensions.