### PR TITLE
fix: Coverage button not visible

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import {
     getFileLineCoverage,
 } from './model'
 import { resolveEndpoint, resolveSettings, Settings } from './settings'
-import { codecovParamsForRepositoryCommit, resolveURI } from './uri'
+import { codecovParamsForRepositoryCommit, resolveFileURI, resolveRootURI } from './uri'
 
 const decorationType =
     sourcegraph.app.createDecorationType &&
@@ -31,7 +31,7 @@ export function activate(): void {
         try {
             for (const editor of editors) {
                 const decorations = await getFileLineCoverage(
-                    resolveURI(editor.document.uri),
+                    resolveFileURI(editor.document.uri),
                     settings['codecov.endpoints'][0],
                     sourcegraph
                 )
@@ -66,7 +66,7 @@ export function activate(): void {
         } else {
             return
         }
-        const lastURI = resolveURI(uri)
+        const lastURI = resolveRootURI(uri)
         const endpoint = resolveEndpoint(
             sourcegraph.configuration.get<Settings>().get('codecov.endpoints')
         )

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,8 +8,8 @@ import {
 import { resolveEndpoint, resolveSettings, Settings } from './settings'
 import {
     codecovParamsForRepositoryCommit,
-    resolveFileURI,
-    resolveURI,
+    resolveDocumentURI,
+    resolveRootURI,
 } from './uri'
 
 const decorationType =
@@ -35,7 +35,7 @@ export function activate(): void {
         try {
             for (const editor of editors) {
                 const decorations = await getFileLineCoverage(
-                    resolveFileURI(editor.document.uri),
+                    resolveDocumentURI(editor.document.uri),
                     settings['codecov.endpoints'][0],
                     sourcegraph
                 )
@@ -70,7 +70,7 @@ export function activate(): void {
         } else {
             return
         }
-        const lastURI = resolveURI(uri)
+        const lastURI = resolveRootURI(uri)
         const endpoint = resolveEndpoint(
             sourcegraph.configuration.get<Settings>().get('codecov.endpoints')
         )

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,11 @@ import {
     getFileLineCoverage,
 } from './model'
 import { resolveEndpoint, resolveSettings, Settings } from './settings'
-import { codecovParamsForRepositoryCommit, resolveFileURI, resolveRootURI } from './uri'
+import {
+    codecovParamsForRepositoryCommit,
+    resolveFileURI,
+    resolveURI,
+} from './uri'
 
 const decorationType =
     sourcegraph.app.createDecorationType &&
@@ -66,7 +70,7 @@ export function activate(): void {
         } else {
             return
         }
-        const lastURI = resolveRootURI(uri)
+        const lastURI = resolveURI(uri)
         const endpoint = resolveEndpoint(
             sourcegraph.configuration.get<Settings>().get('codecov.endpoints')
         )

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,6 +1,6 @@
 import { CodecovCommitData, codecovGetCommitCoverage } from './api'
 import { Endpoint } from './settings'
-import { codecovParamsForRepositoryCommit, ResolvedURI } from './uri'
+import { codecovParamsForRepositoryCommit, ResolvedFileURI, ResolvedURI } from './uri'
 
 export interface FileLineCoverage {
     [line: string]: LineCoverage
@@ -24,7 +24,7 @@ export async function getCommitCoverageRatio(
 
 /** Gets line coverage data for a file at a given commit in a repository. */
 export async function getFileLineCoverage(
-    { repo, rev, path }: ResolvedURI,
+    { repo, rev, path }: ResolvedFileURI,
     endpoint: Endpoint,
     sourcegraph: typeof import('sourcegraph')
 ): Promise<FileLineCoverage> {

--- a/src/model.ts
+++ b/src/model.ts
@@ -2,8 +2,8 @@ import { CodecovCommitData, codecovGetCommitCoverage } from './api'
 import { Endpoint } from './settings'
 import {
     codecovParamsForRepositoryCommit,
-    ResolvedFileURI,
-    ResolvedURI,
+    ResolvedDocumentURI,
+    ResolvedRootURI,
 } from './uri'
 
 export interface FileLineCoverage {
@@ -14,7 +14,7 @@ export type LineCoverage = number | { hits: number; branches: number } | null
 
 /** Gets the coverage ratio for a commit. */
 export async function getCommitCoverageRatio(
-    { repo, rev }: Pick<ResolvedURI, 'repo' | 'rev'>,
+    { repo, rev }: Pick<ResolvedRootURI, 'repo' | 'rev'>,
     endpoint: Endpoint,
     sourcegraph: typeof import('sourcegraph')
 ): Promise<number | undefined> {
@@ -28,7 +28,7 @@ export async function getCommitCoverageRatio(
 
 /** Gets line coverage data for a file at a given commit in a repository. */
 export async function getFileLineCoverage(
-    { repo, rev, path }: ResolvedFileURI,
+    { repo, rev, path }: ResolvedDocumentURI,
     endpoint: Endpoint,
     sourcegraph: typeof import('sourcegraph')
 ): Promise<FileLineCoverage> {
@@ -42,7 +42,7 @@ export async function getFileLineCoverage(
 
 /** Gets the file coverage ratios for all files at a given commit in a repository. */
 export async function getFileCoverageRatios(
-    { repo, rev }: Pick<ResolvedURI, 'repo' | 'rev'>,
+    { repo, rev }: Pick<ResolvedRootURI, 'repo' | 'rev'>,
     endpoint: Endpoint,
     sourcegraph: typeof import('sourcegraph')
 ): Promise<{ [path: string]: number }> {

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,6 +1,10 @@
 import { CodecovCommitData, codecovGetCommitCoverage } from './api'
 import { Endpoint } from './settings'
-import { codecovParamsForRepositoryCommit, ResolvedFileURI, ResolvedURI } from './uri'
+import {
+    codecovParamsForRepositoryCommit,
+    ResolvedFileURI,
+    ResolvedURI,
+} from './uri'
 
 export interface FileLineCoverage {
     [line: string]: LineCoverage

--- a/src/uri.test.ts
+++ b/src/uri.test.ts
@@ -8,7 +8,8 @@ describe('resolveFileURI', () => {
     for (const p of UNSUPPORTED_SCHEMES) {
         it(`throws for ${p} uris`, () => {
             assert.throws(
-                () => resolveFileURI('git://github.com/sourcegraph/sourcegraph'),
+                () =>
+                    resolveFileURI('git://github.com/sourcegraph/sourcegraph'),
                 `Invalid protocol: ${p}`
             )
         })

--- a/src/uri.test.ts
+++ b/src/uri.test.ts
@@ -1,15 +1,17 @@
 import { createStubSourcegraphAPI } from '@sourcegraph/extension-api-stubs'
 import * as assert from 'assert'
-import { codecovParamsForRepositoryCommit, resolveFileURI } from './uri'
+import { codecovParamsForRepositoryCommit, resolveDocumentURI } from './uri'
 
-describe('resolveFileURI', () => {
+describe('resolveDocumentURI', () => {
     const UNSUPPORTED_SCHEMES = ['file:', 'http:', 'https:']
 
     for (const p of UNSUPPORTED_SCHEMES) {
         it(`throws for ${p} uris`, () => {
             assert.throws(
                 () =>
-                    resolveFileURI('git://github.com/sourcegraph/sourcegraph'),
+                    resolveDocumentURI(
+                        'git://github.com/sourcegraph/sourcegraph'
+                    ),
                 `Invalid protocol: ${p}`
             )
         })
@@ -17,19 +19,19 @@ describe('resolveFileURI', () => {
 
     it('throws if url.search is falsy', () => {
         assert.throws(() =>
-            resolveFileURI('git://github.com/sourcegraph/sourcegraph')
+            resolveDocumentURI('git://github.com/sourcegraph/sourcegraph')
         )
     })
 
     it('throws if url.hash is falsy', () => {
         assert.throws(() =>
-            resolveFileURI('git://github.com/sourcegraph/sourcegraph')
+            resolveDocumentURI('git://github.com/sourcegraph/sourcegraph')
         )
     })
 
     it('resolves git: URIs', () => {
         assert.deepStrictEqual(
-            resolveFileURI(
+            resolveDocumentURI(
                 'git://github.com/sourcegraph/sourcegraph?a8215fe4bd9571b43d7a03277069445adca85b2a#pkg/extsvc/github/codehost.go'
             ),
             {

--- a/src/uri.test.ts
+++ b/src/uri.test.ts
@@ -1,14 +1,14 @@
 import { createStubSourcegraphAPI } from '@sourcegraph/extension-api-stubs'
 import * as assert from 'assert'
-import { codecovParamsForRepositoryCommit, resolveURI } from './uri'
+import { codecovParamsForRepositoryCommit, resolveFileURI } from './uri'
 
-describe('resolveURI', () => {
+describe('resolveFileURI', () => {
     const UNSUPPORTED_SCHEMES = ['file:', 'http:', 'https:']
 
     for (const p of UNSUPPORTED_SCHEMES) {
         it(`throws for ${p} uris`, () => {
             assert.throws(
-                () => resolveURI('git://github.com/sourcegraph/sourcegraph'),
+                () => resolveFileURI('git://github.com/sourcegraph/sourcegraph'),
                 `Invalid protocol: ${p}`
             )
         })
@@ -16,19 +16,19 @@ describe('resolveURI', () => {
 
     it('throws if url.search is falsy', () => {
         assert.throws(() =>
-            resolveURI('git://github.com/sourcegraph/sourcegraph')
+            resolveFileURI('git://github.com/sourcegraph/sourcegraph')
         )
     })
 
     it('throws if url.hash is falsy', () => {
         assert.throws(() =>
-            resolveURI('git://github.com/sourcegraph/sourcegraph')
+            resolveFileURI('git://github.com/sourcegraph/sourcegraph')
         )
     })
 
     it('resolves git: URIs', () => {
         assert.deepStrictEqual(
-            resolveURI(
+            resolveFileURI(
                 'git://github.com/sourcegraph/sourcegraph?a8215fe4bd9571b43d7a03277069445adca85b2a#pkg/extsvc/github/codehost.go'
             ),
             {

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -4,7 +4,7 @@ import { Endpoint, Settings } from './settings'
 /**
  * A resolved URI without an identified path.
  */
-export interface ResolvedURI {
+export interface ResolvedRootURI {
     repo: string
     rev: string
 }
@@ -12,14 +12,14 @@ export interface ResolvedURI {
 /**
  * A resolved URI with an identified path in a repository at a specific revision.
  */
-export interface ResolvedFileURI extends ResolvedURI {
+export interface ResolvedDocumentURI extends ResolvedRootURI {
     path: string
 }
 
 /**
  * Resolve a URI of the forms git://github.com/owner/repo?rev, using the given base (root) URI.
  */
-export function resolveURI(uri: string): ResolvedURI {
+export function resolveRootURI(uri: string): ResolvedRootURI {
     const url = new URL(uri)
     if (url.protocol !== 'git:') {
         throw new Error(`Unsupported protocol: ${url.protocol}`)
@@ -35,9 +35,9 @@ export function resolveURI(uri: string): ResolvedURI {
 /**
  * Resolve a URI of the forms git://github.com/owner/repo?rev#path and file:///path to an absolute reference
  */
-export function resolveFileURI(uri: string): ResolvedFileURI {
+export function resolveDocumentURI(uri: string): ResolvedDocumentURI {
     return {
-        ...resolveURI(uri),
+        ...resolveRootURI(uri),
         path: new URL(uri).hash.slice(1),
     }
 }
@@ -53,7 +53,7 @@ export interface KnownHost {
  * Currently only GitHub.com repositories are supported.
  */
 export function codecovParamsForRepositoryCommit(
-    uri: Pick<ResolvedURI, 'repo' | 'rev'>,
+    uri: Pick<ResolvedRootURI, 'repo' | 'rev'>,
     sourcegraph: typeof import('sourcegraph')
 ): Pick<
     CodecovGetCommitCoverageArgs,

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -17,7 +17,7 @@ export interface ResolvedDocumentURI extends ResolvedRootURI {
 }
 
 /**
- * Resolve a URI of the forms git://github.com/owner/repo?rev, using the given base (root) URI.
+ * Resolve a URI of the form git://github.com/owner/repo?rev to an absolute reference.
  */
 export function resolveRootURI(uri: string): ResolvedRootURI {
     const url = new URL(uri)
@@ -33,7 +33,7 @@ export function resolveRootURI(uri: string): ResolvedRootURI {
 }
 
 /**
- * Resolve a URI of the forms git://github.com/owner/repo?rev#path and file:///path to an absolute reference
+ * Resolve a URI of the form git://github.com/owner/repo?rev#path to an absolute reference.
  */
 export function resolveDocumentURI(uri: string): ResolvedDocumentURI {
     return {

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -7,7 +7,7 @@ import { Endpoint, Settings } from './settings'
 export interface ResolvedURI {
     repo: string
     rev: string
-    path: string
+    path?: string
 }
 
 /**
@@ -24,11 +24,8 @@ export function resolveURI(uri: string): ResolvedURI {
     if (!rev) {
         throw new Error('Could not determine revision')
     }
-    const path = url.hash.slice(1)
-    console.log(uri, path)
-    if (!path) {
-        throw new Error('Could not determine file path')
-    }
+    const path = url.hash.slice(1) || undefined
+
     return {
         repo,
         rev,

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -16,7 +16,11 @@ export interface ResolvedFileURI extends ResolvedURI {
     path: string
 }
 
-function resolveURI(url: URL): ResolvedURI {
+/**
+ * Resolve a URI of the forms git://github.com/owner/repo?rev, using the given base (root) URI.
+ */
+export function resolveURI(uri: string): ResolvedURI {
+    const url = new URL(uri)
     if (url.protocol !== 'git:') {
         throw new Error(`Unsupported protocol: ${url.protocol}`)
     }
@@ -32,19 +36,10 @@ function resolveURI(url: URL): ResolvedURI {
  * Resolve a URI of the forms git://github.com/owner/repo?rev#path and file:///path to an absolute reference
  */
 export function resolveFileURI(uri: string): ResolvedFileURI {
-    const url = new URL(uri)
-    const path = url.hash.slice(1)
     return {
-        ...resolveURI(url),
-        path,
+        ...resolveURI(uri),
+        path: new URL(uri).hash.slice(1),
     }
-}
-
-/**
- * Resolve a URI of the forms git://github.com/owner/repo?rev, using the given base (root) URI.
- */
-export function resolveRootURI(uri: string): ResolvedURI {
-    return resolveURI(new URL(uri))
 }
 
 export interface KnownHost {


### PR DESCRIPTION
- fixes #37
- update interface ResolvedURI to reflect resolveURI not throwing on `!path` (#34)