### PR TITLE
Use activeWindowChanges, activeViewComponentChanges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10247,9 +10247,9 @@
       }
     },
     "rxjs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
-      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -279,6 +279,7 @@
     "nyc": "^12.0.2",
     "parcel-bundler": "^1.12.3",
     "prettier": "^1.18.2",
+    "rxjs": "^6.5.3",
     "source-map-support": "^0.5.12",
     "sourcegraph": "^23.0.1",
     "ts-node": "^7.0.1",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,11 @@
 import { BehaviorSubject, combineLatest, from, Subscription } from 'rxjs'
 import {
+    catchError,
+    concatMap,
     filter,
     map,
     startWith,
     switchMap,
-    concatMap,
-    catchError,
 } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import { codecovToDecorations } from './decoration'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,5 @@
+import { BehaviorSubject, combineLatest, from, Subscription } from 'rxjs'
+import { filter, map, startWith, switchMap } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import { codecovToDecorations } from './decoration'
 import {
@@ -5,7 +7,12 @@ import {
     getFileCoverageRatios,
     getFileLineCoverage,
 } from './model'
-import { resolveEndpoint, resolveSettings, Settings } from './settings'
+import {
+    Endpoint,
+    resolveEndpoint,
+    resolveSettings,
+    Settings,
+} from './settings'
 import {
     codecovParamsForRepositoryCommit,
     resolveDocumentURI,
@@ -17,63 +24,107 @@ const decorationType =
     sourcegraph.app.createDecorationType()
 
 /** Entrypoint for the Codecov Sourcegraph extension. */
-export function activate(): void {
-    function activeEditors(): sourcegraph.CodeEditor[] {
-        return sourcegraph.app.activeWindow
-            ? sourcegraph.app.activeWindow.visibleViewComponents
-            : []
+export function activate(
+    context: sourcegraph.ExtensionContext = {
+        subscriptions: new Subscription(),
     }
+): void {
+    /**
+     * An Observable that emits the active window's visible view components
+     * when the active window or its view components change.
+     */
+    const editorsChanges = sourcegraph.app.activeWindowChanges
+        ? from(sourcegraph.app.activeWindowChanges).pipe(
+              filter(
+                  (activeWindow): activeWindow is sourcegraph.Window =>
+                      activeWindow !== undefined
+              ),
+              switchMap(activeWindow =>
+                  from(activeWindow.activeViewComponentChanges).pipe(
+                      map(() => activeWindow.visibleViewComponents)
+                  )
+              )
+              // Backcompat: rely on onDidOpenTextDocument if the extension host doesn't support activeWindowChanges / activeViewComponentChanges
+          )
+        : from(sourcegraph.workspace.onDidOpenTextDocument).pipe(
+              map(
+                  () =>
+                      (sourcegraph.app.activeWindow &&
+                          sourcegraph.app.activeWindow.visibleViewComponents) ||
+                      []
+              )
+          )
 
     // When the configuration or current file changes, publish new decorations.
     //
     // TODO: Unpublish decorations on previously (but not currently) open files when settings changes, to avoid a
     // brief flicker of the old state when the file is reopened.
-    async function decorate(editors = activeEditors()): Promise<void> {
-        const settings = resolveSettings(
-            sourcegraph.configuration.get<Settings>().value
-        )
-        try {
-            for (const editor of editors) {
-                const decorations = await getFileLineCoverage(
-                    resolveDocumentURI(editor.document.uri),
-                    settings['codecov.endpoints'][0],
-                    sourcegraph
-                )
-                editor.setDecorations(
-                    decorationType,
-                    codecovToDecorations(settings, decorations)
-                )
-            }
-        } catch (err) {
-            console.error('Decoration error:', err)
+    async function decorate(
+        settings: Readonly<Settings>,
+        editors: sourcegraph.CodeEditor[]
+    ): Promise<void> {
+        const resolvedSettings = resolveSettings(settings)
+        for (const editor of editors) {
+            const decorations = await getFileLineCoverage(
+                resolveDocumentURI(editor.document.uri),
+                resolvedSettings['codecov.endpoints'][0],
+                sourcegraph
+            )
+            editor.setDecorations(
+                decorationType,
+                codecovToDecorations(settings, decorations)
+            )
         }
     }
-    sourcegraph.configuration.subscribe(() => decorate())
-    // TODO(sqs): Add a way to get notified when a new editor is opened (because we want to be able to pass an `editor` to `updateDecorations`/`updateContext`, but this subscription just gives us a `doc`).
-    sourcegraph.workspace.onDidOpenTextDocument.subscribe(() => decorate())
+
+    /**
+     * A BehaviorSubject of the extension's resolved {@link Settings}.
+     */
+    const configurationChanges = new BehaviorSubject<Readonly<Settings>>(
+        sourcegraph.configuration.get<Settings>().value
+    )
+    context.subscriptions.add(
+        sourcegraph.configuration.subscribe(() =>
+            configurationChanges.next(
+                sourcegraph.configuration.get<Settings>().value
+            )
+        )
+    )
+    context.subscriptions.add(
+        combineLatest([
+            configurationChanges,
+            editorsChanges,
+            // tslint:disable-next-line: rxjs-no-async-subscribe
+        ]).subscribe(async ([settings, editors]) => {
+            try {
+                await decorate(settings, editors)
+            } catch (err) {
+                console.error('Codecov: decoration error', err)
+            }
+        })
+    )
 
     // Set context values referenced in template expressions in the extension manifest (e.g., to interpolate "N" in
     // the "Coverage: N%" button label).
     //
     // The context only needs to be updated when the endpoints configuration changes.
-    async function updateContext(editors = activeEditors()): Promise<void> {
+    async function updateContext(
+        endpoints: readonly Endpoint[] | undefined,
+        roots: readonly sourcegraph.WorkspaceRoot[],
+        editors: sourcegraph.CodeEditor[]
+    ): Promise<void> {
         // Get the current repository. Sourcegraph 3.0-preview exposes sourcegraph.workspace.roots, but earlier
         // versions do not.
         let uri: string
-        if (
-            sourcegraph.workspace.roots &&
-            sourcegraph.workspace.roots.length > 0
-        ) {
-            uri = sourcegraph.workspace.roots[0].uri.toString()
+        if (roots && roots.length > 0) {
+            uri = roots[0].uri.toString()
         } else if (editors.length > 0) {
             uri = editors[0].document.uri
         } else {
             return
         }
         const lastURI = resolveRootURI(uri)
-        const endpoint = resolveEndpoint(
-            sourcegraph.configuration.get<Settings>().get('codecov.endpoints')
-        )
+        const endpoint = resolveEndpoint(endpoints)
 
         const context: {
             [key: string]: string | number | boolean | null
@@ -115,11 +166,32 @@ export function activate(): void {
         }
         sourcegraph.internal.updateContext(context)
     }
-    sourcegraph.configuration.subscribe(() => updateContext())
-    sourcegraph.workspace.onDidOpenTextDocument.subscribe(() => updateContext())
-    if (sourcegraph.workspace.onDidChangeRoots) {
-        sourcegraph.workspace.onDidChangeRoots.subscribe(() => updateContext())
-    }
+
+    // Update the context when the configuration, workspace roots or active editors change.
+    context.subscriptions.add(
+        combineLatest([
+            configurationChanges.pipe(
+                map(settings => settings['codecov.endpoints'])
+            ),
+            // Backcompat: rely on onDidChangeRoots if the extension host doesn't support rootChanges.
+            from(
+                sourcegraph.workspace.rootChanges
+                    ? sourcegraph.workspace.roots
+                    : sourcegraph.workspace.onDidChangeRoots
+            ).pipe(
+                map(() => sourcegraph.workspace.roots),
+                startWith(sourcegraph.workspace.roots)
+            ),
+            editorsChanges,
+            // tslint:disable-next-line: rxjs-no-async-subscribe
+        ]).subscribe(async ([endpoints, roots, editors]) => {
+            try {
+                await updateContext(endpoints, roots, editors)
+            } catch (err) {
+                console.error('codecov: error updating context', err)
+            }
+        })
+    )
 
     sourcegraph.commands.registerCommand(
         'codecov.setupEnterprise',


### PR DESCRIPTION
The Codecov extension still used workspace.onDidOpenTextDocument, which can be subject to race conditions (the event can be fired before the Codecov extension is activated). This is changed to use `workspace.activeWindowChanges` and `Window.activeViewComponentChanges` when available, to reliably decorate editors.

Also makes sure that all subscriptions are correctly handled through context.Subscriptions.