### PR TITLE
Resolve repo names using the GraphQL API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11261,9 +11261,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
-      "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
     },
     "uncss": {

--- a/package.json
+++ b/package.json
@@ -285,6 +285,6 @@
     "ts-node": "^7.0.1",
     "tslint": "^5.18.0",
     "tslint-language-service": "^0.9.9",
-    "typescript": "^3.5.2"
+    "typescript": "^3.7.5"
   }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,3 +1,5 @@
+import { memoizeAsync } from './memoizeAsync'
+
 /** The arguments for getCommitCoverage. */
 export interface CodecovGetCommitCoverageArgs {
     /**
@@ -114,29 +116,4 @@ function commitCoverageURL({
 
     // The ?src=extension is necessary to get the data for all files in the response.
     return `${baseURL}/api/${service}/${owner}/${repo}/commits/${sha}?src=extension${tokenSuffix}`
-}
-
-/**
- * Creates a function that memoizes the async result of func. If the Promise is rejected, the result will not be
- * cached.
- *
- * @param toKey etermines the cache key for storing the result based on the first argument provided to the memoized
- * function
- */
-function memoizeAsync<P, T>(
-    func: (params: P) => Promise<T>,
-    toKey: (params: P) => string
-): (params: P) => Promise<T> {
-    const cache = new Map<string, Promise<T>>()
-    return (params: P) => {
-        const key = toKey(params)
-        const hit = cache.get(key)
-        if (hit) {
-            return hit
-        }
-        const p = func(params)
-        p.then(null, () => cache.delete(key))
-        cache.set(key, p)
-        return p
-    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import { BehaviorSubject, combineLatest, from, Subscription } from 'rxjs'
 import { concatMap, filter, map, startWith, switchMap } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import { codecovToDecorations } from './decoration'
+import { resolveRepoName } from './graphql'
 import {
     getCommitCoverageRatio,
     getFileCoverageRatios,
@@ -68,7 +69,7 @@ export function activate(
         const resolvedSettings = resolveSettings(settings)
         for (const editor of editors) {
             const decorations = await getFileLineCoverage(
-                resolveDocumentURI(editor.document.uri),
+                await resolveDocumentURI(editor.document.uri, resolveRepoName),
                 resolvedSettings['codecov.endpoints'][0],
                 sourcegraph
             )
@@ -128,7 +129,7 @@ export function activate(
         } else {
             return
         }
-        const lastURI = resolveRootURI(uri)
+        const lastURI = await resolveRootURI(uri, resolveRepoName)
         const endpoint = resolveEndpoint(endpoints)
 
         const context: {

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,0 +1,48 @@
+import * as sourcegraph from 'sourcegraph'
+import { memoizeAsync } from './memoizeAsync'
+
+interface ResolveRepoNameResponse {
+    data?: {
+        repository?: {
+            uri: string
+        }
+    }
+}
+
+/**
+ * Attempts to use the Sourcegraph graphQL API to resolve a repo name
+ * parsed from a resource URI, possibly affected by repositoryPathPattern,
+ * to the repo's URI, unaffected by repositoryPathPattern,
+ * typically of the form "{host}/{nameWithOwner}" (eg. "github.com/sourcegraph/enterprise").
+ *
+ * Example: with `"repositoryPathPattern": "{nameWithOwner}"` set in synced repository
+ * settings for a github.com code host, this would resolve the repo name "sourcegraph/enterprise"
+ * to "github.com/sourcegraph/enterprise".
+ *
+ * If the graphQL request fails (this can happen on private repositories when the Sourcegraph
+ * browser extension points to the public sourcegraph.com instance), the returned Promise
+ * will resolve to the repo name passed as argument.
+ */
+export const resolveRepoName = memoizeAsync(async (name: string): Promise<string> => {
+    try {
+        const result = await sourcegraph.commands.executeCommand<
+            ResolveRepoNameResponse
+        >(
+            'queryGraphQL',
+            `query ResolveRepoURI($name: String!) {
+                repository(name: $name) {
+                    uri
+                }
+            }`,
+            { name }
+        )
+        const uri = result?.data?.repository?.uri
+        if (!uri) {
+            throw new Error('bad response')
+        }
+        return uri
+    } catch (err) {
+        console.warn(`Could not resolve repo name: ${err}`)
+    }
+    return name
+}, name => name)

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -42,7 +42,7 @@ export const resolveRepoName = memoizeAsync(async (name: string): Promise<string
         }
         return uri
     } catch (err) {
-        console.warn(`Could not resolve repo name: ${err}`)
+        console.warn('Could not resolve repo name', err)
     }
     return name
 }, name => name)

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -3,7 +3,7 @@ import { memoizeAsync } from './memoizeAsync'
 
 interface ResolveRepoNameResponse {
     data?: {
-        repository?: {
+        repository: null | {
             uri: string
         }
     }

--- a/src/memoizeAsync.ts
+++ b/src/memoizeAsync.ts
@@ -1,0 +1,24 @@
+/**
+ * Creates a function that memoizes the async result of func. If the Promise is rejected, the result will not be
+ * cached.
+ *
+ * @param toKey etermines the cache key for storing the result based on the first argument provided to the memoized
+ * function
+ */
+export function memoizeAsync<P, T>(
+    func: (params: P) => Promise<T>,
+    toKey: (params: P) => string
+): (params: P) => Promise<T> {
+    const cache = new Map<string, Promise<T>>()
+    return (params: P) => {
+        const key = toKey(params)
+        const hit = cache.get(key)
+        if (hit) {
+            return hit
+        }
+        const p = func(params)
+        p.then(null, () => cache.delete(key))
+        cache.set(key, p)
+        return p
+    }
+}

--- a/src/uri.test.ts
+++ b/src/uri.test.ts
@@ -5,39 +5,62 @@ import { codecovParamsForRepositoryCommit, resolveDocumentURI } from './uri'
 describe('resolveDocumentURI', () => {
     const UNSUPPORTED_SCHEMES = ['file:', 'http:', 'https:']
 
+    const MOCK_RESOLVE_REPO_NAME = (name: string): Promise<string> =>
+        Promise.resolve(name)
+
     for (const p of UNSUPPORTED_SCHEMES) {
-        it(`throws for ${p} uris`, () => {
-            assert.throws(
-                () =>
-                    resolveDocumentURI(
-                        'git://github.com/sourcegraph/sourcegraph'
-                    ),
+        it(`throws for ${p} uris`, async () => {
+            await assert.rejects(
+                resolveDocumentURI(
+                    `${p}://github.com/sourcegraph/sourcegraph`,
+                    MOCK_RESOLVE_REPO_NAME
+                ),
                 `Invalid protocol: ${p}`
             )
         })
     }
 
-    it('throws if url.search is falsy', () => {
-        assert.throws(() =>
-            resolveDocumentURI('git://github.com/sourcegraph/sourcegraph')
-        )
-    })
-
-    it('throws if url.hash is falsy', () => {
-        assert.throws(() =>
-            resolveDocumentURI('git://github.com/sourcegraph/sourcegraph')
-        )
-    })
-
-    it('resolves git: URIs', () => {
-        assert.deepStrictEqual(
+    it('throws if url.search is falsy', async () => {
+        await assert.rejects(() =>
             resolveDocumentURI(
-                'git://github.com/sourcegraph/sourcegraph?a8215fe4bd9571b43d7a03277069445adca85b2a#pkg/extsvc/github/codehost.go'
+                'git://github.com/sourcegraph/sourcegraph',
+                MOCK_RESOLVE_REPO_NAME
+            )
+        )
+    })
+
+    it('throws if url.hash is falsy', async () => {
+        await assert.rejects(() =>
+            resolveDocumentURI(
+                'git://github.com/sourcegraph/sourcegraph',
+                MOCK_RESOLVE_REPO_NAME
+            )
+        )
+    })
+
+    it('resolves git: URIs', async () => {
+        assert.deepStrictEqual(
+            await resolveDocumentURI(
+                'git://github.com/sourcegraph/sourcegraph?a8215fe4bd9571b43d7a03277069445adca85b2a#pkg/extsvc/github/codehost.go',
+                MOCK_RESOLVE_REPO_NAME
             ),
             {
                 path: 'pkg/extsvc/github/codehost.go',
                 repo: 'github.com/sourcegraph/sourcegraph',
                 rev: 'a8215fe4bd9571b43d7a03277069445adca85b2a',
+            }
+        )
+    })
+
+    it('returns the repo name resolved from the Sourcegraph instance', async () => {
+        assert.deepStrictEqual(
+            await resolveDocumentURI('git://a/b?c#d/e.go', name =>
+                Promise.resolve(`github.com/${name}`)
+            ),
+            {
+                path: 'd/e.go',
+                repo: 'github.com/a/b',
+                rev: 'c',
             }
         )
     })

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -30,7 +30,6 @@ export async function resolveRootURI(
     const rawRepo = (url.host + url.pathname).replace(/^\/*/, '')
     const repo = await resolveRepoName(rawRepo)
     const rev = url.search.slice(1)
-    console.log({ repo, rev })
     if (!rev) {
         throw new Error('Could not determine revision')
     }


### PR DESCRIPTION
Resource URIs exposed to Sourcegraph extensions are always affected by repositoryPathPattern, and as such may not contain code host's hostname (eg. `"git://sourcegraph/enterprise"` rather than `"git://github.com/sourcegraph/enterprise"`).

This is problematic for the Codecov extension, which attempts to parse the code host's hostname from resource URIs to build API URLs.

With this PR, the Codecov extension now uses the GraphQL API to resolve a repository name, possibly affected by repositoryPathPattern, to the repo's URI, unaffected by repositoryPathPattern (eg. `sourcegraph/enterprise` -> `github.com/sourcegraph/enterprise`)