### PR TITLE
Add icon to coverage button

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
         "actionItem": {
           "label": "Coverage: ${get(context, `codecov.coverageRatio.${resource.uri}`)}%",
           "description": "${config.codecov.decorations.lineCoverage && \"Hide\" || \"Show\"} code coverage\nCmd/Ctrl+Click: View on Codecov",
-          "pressed": "config.codecov.decorations.lineCoverage"
+          "pressed": "config.codecov.decorations.lineCoverage",
+          "iconURL": "https://raw.githubusercontent.com/codecov/media/master/logos/logo.svg?sanitize=true"
         }
       },
       {


### PR DESCRIPTION
This is what it looks like:

![image](https://user-images.githubusercontent.com/10532611/78258647-d2c59980-74fb-11ea-9cce-cb20846558ee.png)
