### PR TITLE
Fix logo URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
           "label": "Coverage: ${get(context, `codecov.coverageRatio.${resource.uri}`)}%",
           "description": "${config.codecov.decorations.lineCoverage && \"Hide\" || \"Show\"} code coverage\nCmd/Ctrl+Click: View on Codecov",
           "pressed": "config.codecov.decorations.lineCoverage",
-          "iconURL": "https://raw.githubusercontent.com/codecov/media/master/logos/logo.svg?sanitize=true"
+          "iconURL": "https://raw.githubusercontent.com/codecov/media/master/logos/codecov%20logo%20mark%20pink.svg?sanitize=true"
         }
       },
       {


### PR DESCRIPTION
Was changed 1h ago: https://github.com/codecov/media/commit/ed41433db6f78bf21d803d18a66c85822d91a29f

Currently broken on sourcegraph.com

![image](https://user-images.githubusercontent.com/19534377/78417121-4ddb9c80-762f-11ea-8f57-599af2a35862.png)
