### PR TITLE
Refactors in preparation for directory providers

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,6 +6,11 @@
       "script": "watch:typecheck",
       "problemMatcher": ["$tsc-watch"],
       "isBackground": true
+    },
+    {
+      "type": "npm",
+      "script": "serve",
+      "problemMatcher": []
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2256,18 +2256,18 @@
       "dev": true
     },
     "@sinonjs/commons": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
-      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
+      "integrity": "sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
     },
     "@sinonjs/formatio": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
-      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1",
@@ -2275,14 +2275,14 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.2.tgz",
-      "integrity": "sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.0.2",
+        "@sinonjs/commons": "^1.3.0",
         "array-from": "^2.1.1",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.15"
       }
     },
     "@sinonjs/text-encoding": {
@@ -2292,39 +2292,39 @@
       "dev": true
     },
     "@sourcegraph/extension-api-classes": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@sourcegraph/extension-api-classes/-/extension-api-classes-1.0.2.tgz",
-      "integrity": "sha512-2PUTf/hedG+5DTyUmA2QPK7I/qyiwIbgQHcmAeRGlysg17okOeNFRp4AVLJsAh+NLq8poxtbyXP+dIdrCzONgw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@sourcegraph/extension-api-classes/-/extension-api-classes-1.0.3.tgz",
+      "integrity": "sha512-nGDB8IAyDmA3/kaMYkYk4eOdUT4DGAJGcxGEe7zjRNywvktRH63eXdPttQCOkazpGmq3udL7Ael/HQmynkUzcw==",
       "dev": true,
       "requires": {
-        "@sourcegraph/extension-api-types": "^2.0.0"
+        "@sourcegraph/extension-api-types": "^2.1.0"
       }
     },
     "@sourcegraph/extension-api-stubs": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@sourcegraph/extension-api-stubs/-/extension-api-stubs-0.2.2.tgz",
-      "integrity": "sha512-3jVSf5EKWwQOS9RDPZ2Kkb1tOlPflrrbch32WO28HSBPGNtIdYqYkJ4SLa8PNHXyE3lxuEnLJI7x3QuG6rr17g==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@sourcegraph/extension-api-stubs/-/extension-api-stubs-0.2.6.tgz",
+      "integrity": "sha512-rRuf6Y0o7b1dJYEhMspA3tuAtHb8pku9y6JwJ8WI40mEk0cv29xOn+HUN46ZuDDuoAY4LQ1seWMvVWcutgZDjw==",
       "dev": true,
       "requires": {
-        "@sourcegraph/extension-api-classes": "^1.0.2",
-        "@types/sinon": "7.0.13",
+        "@sourcegraph/extension-api-classes": "^1.0.3",
+        "@types/sinon": "7.5.2",
         "rxjs": "^6.5.1",
-        "sinon": "^7.3.2",
-        "sourcegraph": "^23.0.1"
+        "sinon": "^7.5.0",
+        "sourcegraph": "^24.0.0"
       },
       "dependencies": {
         "sourcegraph": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/sourcegraph/-/sourcegraph-23.0.1.tgz",
-          "integrity": "sha512-4We7zqhOagOVxNFdS6/xT/Crhb0Arw/9ytGBu8JuHfjo5yjMtcUYt22kZyu2TaPHXwyPW9muUi1eKSFA6Qg4lw==",
+          "version": "24.0.0",
+          "resolved": "https://registry.npmjs.org/sourcegraph/-/sourcegraph-24.0.0.tgz",
+          "integrity": "sha512-SQtLGJ0mvCm2vQV5ABNDNXuGWqCL4rdkFWy1EAbGeDk5NrbY/KCfH6rH/4ZTl0YVyL5mYO5squMcdxjHJX2axw==",
           "dev": true
         }
       }
     },
     "@sourcegraph/extension-api-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sourcegraph/extension-api-types/-/extension-api-types-2.0.0.tgz",
-      "integrity": "sha512-Te7F1RQJLBH4C8wQ2xz0nPC2vpe13F80V+Yv+c3GySOoh4DcLNN4P5u51Kh4aZPqeS5DJ7CKvHyX2SM/1EBXNg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@sourcegraph/extension-api-types/-/extension-api-types-2.1.0.tgz",
+      "integrity": "sha512-KWxkyphmlwam8kfYPSmoitKQRMGQCsr1ZRmNZgijT7ABKaVyk/+I5ezt2J213tM04Hi0vyg4L7iH1VCkNvm2Jw==",
       "dev": true
     },
     "@sourcegraph/tslint-config": {
@@ -2345,6 +2345,15 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
       "dev": true
     },
+    "@types/mock-require": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mock-require/-/mock-require-2.0.0.tgz",
+      "integrity": "sha512-nOgjoE5bBiDeiA+z41i95makyHUSMWQMOPocP+J67Pqx/68HAXaeWN1NFtrAYYV6LrISIZZ8vKHm/a50k0f6Sg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "10.14.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.10.tgz",
@@ -2358,9 +2367,9 @@
       "dev": true
     },
     "@types/sinon": {
-      "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.13.tgz",
-      "integrity": "sha512-d7c/C/+H/knZ3L8/cxhicHUiTDxdgap0b/aNJfsmLwFu/iOP17mdgbQsbHA3SJmrzsjD0l3UEE5SN4xxuz5ung==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
+      "integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==",
       "dev": true
     },
     "abab": {
@@ -2465,6 +2474,12 @@
         }
       }
     },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2529,12 +2544,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-      "dev": true
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asn1": {
@@ -5050,6 +5059,12 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "get-caller-file": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
+    },
     "get-port": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
@@ -5968,9 +5983,9 @@
       }
     },
     "just-extend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
-      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
       "dev": true
     },
     "kind-of": {
@@ -6087,9 +6102,9 @@
       }
     },
     "lolex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
-      "integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
       "dev": true
     },
     "loose-envify": {
@@ -6140,9 +6155,9 @@
       }
     },
     "make-error": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
     "map-cache": {
@@ -6393,12 +6408,24 @@
       }
     },
     "mock-require": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-2.0.2.tgz",
-      "integrity": "sha1-HqpxqtIwE3c9En3H6Ro/u0g31g0=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-3.0.3.tgz",
+      "integrity": "sha512-lLzfLHcyc10MKQnNUCv7dMcoY/2Qxd6wJfbqCcVk3LDb8An4hF6ohk5AztrvgKhJCqj36uyzi/p5se+tvyD+Wg==",
       "dev": true,
       "requires": {
-        "caller-id": "^0.1.0"
+        "get-caller-file": "^1.0.2",
+        "normalize-path": "^2.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
       }
     },
     "ms": {
@@ -6440,16 +6467,27 @@
       "dev": true
     },
     "nise": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.0.tgz",
-      "integrity": "sha512-Z3sfYEkLFzFmL8KY6xnSJLRxwQwYBjOXi/24lb62ZnZiGA0JUzGGTI6TBIgfCSMIDl9Jlu8SRmHNACLTemDHww==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
+      "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/formatio": "^3.2.1",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
-        "lolex": "^4.1.0",
+        "lolex": "^5.0.1",
         "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+          "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        }
       }
     },
     "node-addon-api": {
@@ -9149,9 +9187,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
       "dev": true,
       "requires": {
         "isarray": "0.0.1"
@@ -10502,17 +10540,17 @@
       }
     },
     "sinon": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.2.tgz",
-      "integrity": "sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
+      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.4.0",
         "@sinonjs/formatio": "^3.2.1",
-        "@sinonjs/samsam": "^3.3.1",
+        "@sinonjs/samsam": "^3.3.3",
         "diff": "^3.5.0",
-        "lolex": "^4.0.1",
-        "nise": "^1.4.10",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.2",
         "supports-color": "^5.5.0"
       },
       "dependencies": {
@@ -11092,19 +11130,34 @@
       "dev": true
     },
     "ts-node": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
-      "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.9.1.tgz",
+      "integrity": "sha512-yrq6ODsxEFTLz0R3BX2myf0WBCSQh9A+py8PBo1dCzWIOcvisbyH6akNKqDHMgXePF2kir5mm5JXJTH3OUJYOQ==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.0",
-        "buffer-from": "^1.1.0",
-        "diff": "^3.1.0",
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.5.6",
-        "yn": "^2.0.0"
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
       }
     },
     "tslib": {
@@ -11175,6 +11228,17 @@
       "dev": true,
       "requires": {
         "mock-require": "^2.0.2"
+      },
+      "dependencies": {
+        "mock-require": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-2.0.2.tgz",
+          "integrity": "sha1-HqpxqtIwE3c9En3H6Ro/u0g31g0=",
+          "dev": true,
+          "requires": {
+            "caller-id": "^0.1.0"
+          }
+        }
       }
     },
     "tslint-react": {
@@ -11261,9 +11325,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
-      "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "uncss": {
@@ -11653,9 +11717,9 @@
       "dev": true
     },
     "yn": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -270,22 +270,24 @@
     "last 1 Safari versions"
   ],
   "devDependencies": {
-    "@sourcegraph/extension-api-stubs": "^0.2.2",
+    "@sourcegraph/extension-api-stubs": "^0.2.6",
     "@sourcegraph/tslint-config": "^13.3.0",
     "@types/mocha": "^5.2.7",
+    "@types/mock-require": "^2.0.0",
     "@types/node": "^10.14.10",
     "lnfs-cli": "^2.1.0",
     "mkdirp": "^0.5.1",
     "mocha": "^5.2.0",
+    "mock-require": "^3.0.3",
     "nyc": "^12.0.2",
     "parcel-bundler": "^1.12.3",
     "prettier": "^1.18.2",
     "rxjs": "^6.5.3",
     "source-map-support": "^0.5.12",
     "sourcegraph": "^23.0.1",
-    "ts-node": "^7.0.1",
+    "ts-node": "^8.9.1",
     "tslint": "^5.18.0",
     "tslint-language-service": "^0.9.9",
-    "typescript": "^3.5.2"
+    "typescript": "^3.8.3"
   }
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,4 +1,4 @@
-import { CodecovCommitData, codecovGetCommitCoverage } from './api'
+import { CodecovCommitData, getCommitCoverage } from './api'
 import { Endpoint } from './settings'
 import {
     codecovParamsForRepositoryCommit,
@@ -18,7 +18,7 @@ export async function getCommitCoverageRatio(
     endpoint: Endpoint,
     sourcegraph: typeof import('sourcegraph')
 ): Promise<number | null | undefined> {
-    const data = await codecovGetCommitCoverage({
+    const data = await getCommitCoverage({
         ...codecovParamsForRepositoryCommit({ repo, rev }, sourcegraph),
         baseURL: endpoint.url,
         token: endpoint.token,
@@ -35,7 +35,7 @@ export async function getFileLineCoverage(
     endpoint: Endpoint,
     sourcegraph: typeof import('sourcegraph')
 ): Promise<FileLineCoverage | null> {
-    const data = await codecovGetCommitCoverage({
+    const data = await getCommitCoverage({
         ...codecovParamsForRepositoryCommit({ repo, rev }, sourcegraph),
         baseURL: endpoint.url,
         token: endpoint.token,
@@ -52,7 +52,7 @@ export async function getFileCoverageRatios(
     endpoint: Endpoint,
     sourcegraph: typeof import('sourcegraph')
 ): Promise<{ [path: string]: number } | null> {
-    const data = await codecovGetCommitCoverage({
+    const data = await getCommitCoverage({
         ...codecovParamsForRepositoryCommit({ repo, rev }, sourcegraph),
         baseURL: endpoint.url,
         token: endpoint.token,

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -1,3 +1,7 @@
+import { createStubSourcegraphAPI } from '@sourcegraph/extension-api-stubs'
+import mock from 'mock-require'
+mock('sourcegraph', createStubSourcegraphAPI())
+
 import * as assert from 'assert'
 import { resolveSettings, Settings } from './settings'
 
@@ -26,6 +30,7 @@ describe('Settings', () => {
                     'codecov.decorations.lineHitCounts': true,
                 }),
                 {
+                    'codecov.graphType': undefined,
                     'codecov.decorations.lineCoverage': false,
                     'codecov.decorations.lineHitCounts': true,
                     'codecov.showCoverage': true,
@@ -39,6 +44,7 @@ describe('Settings', () => {
 
         it('applies defaults for the other properties', () =>
             assert.deepStrictEqual(resolveSettings({}), {
+                'codecov.graphType': undefined,
                 'codecov.decorations.lineCoverage': false,
                 'codecov.decorations.lineHitCounts': false,
                 'codecov.showCoverage': true,

--- a/src/uri.test.ts
+++ b/src/uri.test.ts
@@ -1,4 +1,7 @@
 import { createStubSourcegraphAPI } from '@sourcegraph/extension-api-stubs'
+import mock from 'mock-require'
+mock('sourcegraph', createStubSourcegraphAPI())
+
 import * as assert from 'assert'
 import { codecovParamsForRepositoryCommit, resolveDocumentURI } from './uri'
 
@@ -56,11 +59,12 @@ describe('codecovParamsForRepo', () => {
                 sourcegraph
             ),
             {
-                baseURL: '',
+                baseURL: 'https://codecov.io',
                 service: 'gh',
                 owner: 'owner',
                 repo: 'repo',
                 sha: 'v',
+                token: undefined,
             }
         ))
 
@@ -74,11 +78,12 @@ describe('codecovParamsForRepo', () => {
                 sourcegraph
             ),
             {
-                baseURL: '',
+                baseURL: 'https://codecov.io',
                 owner: 'owner',
                 repo: 'repo',
                 service: 'gh',
                 sha: 'v',
+                token: undefined,
             }
         ))
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": ["es2018", "webworker"],
     "sourceMap": true,
     "allowUnreachableCode": false,
+    "esModuleInterop": true,
     "allowUnusedLabels": false,
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": true,


### PR DESCRIPTION
These are necessary changes for the addition of view providers.

- Check that editors are `CodeEditor`s (important - else this extension will break soon!)
- Split types in api.ts up into more individual types.
- Use `URL` API more
- Add API functions to fetch graph SVGs
- Export config Observable from settings.ts
- Add mocked Sourcegraph API to tests