### PR TITLE
Use new chart API to contribute pie charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12301,9 +12301,9 @@
       "dev": true
     },
     "sourcegraph": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/sourcegraph/-/sourcegraph-24.1.0.tgz",
-      "integrity": "sha512-9m/CaPvVYYHHLosCac8syhgy4QnCiRQXqvyXCDvfuTqvFaLwApfOaP2De3cacvrA2Pjj+ZwnvIlxwA1uCFP1Uw==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/sourcegraph/-/sourcegraph-24.2.0.tgz",
+      "integrity": "sha512-hhViwCZuglxLIjHNPI9ffg7DFECJqWYclZEQ8HxPFPAGmawFcBcv9H9H7/6sP5vE48c6cb+O31hVgbIzDB/0TQ==",
       "dev": true
     },
     "spdx-correct": {

--- a/package.json
+++ b/package.json
@@ -307,7 +307,7 @@
     "prettier": "^2.0.5",
     "rxjs": "^6.5.5",
     "source-map-support": "^0.5.19",
-    "sourcegraph": "^24.1.0",
+    "sourcegraph": "^24.2.0",
     "ts-node": "^8.9.1",
     "typescript": "^3.8.3"
   }

--- a/package.json
+++ b/package.json
@@ -184,15 +184,21 @@
     "configuration": {
       "title": "Codecov settings",
       "properties": {
-        "codecov.graphType": {
-          "description": "The type of graph to show on repository pages.",
-          "enum": [
-            "sunburst",
-            "icicle",
-            "tree",
-            null
-          ],
-          "default": null
+        "codecov.insight.icicle": {
+          "description": "Show an interactive coverage icicle graph on repository pages.",
+          "type": "boolean"
+        },
+        "codecov.insight.tree": {
+          "description": "Show a coverage tree map on repository pages.",
+          "type": "boolean"
+        },
+        "codecov.insight.sunburst": {
+          "description": "Show a coverage sunburst graph on repository pages.",
+          "type": "boolean"
+        },
+        "codecov.insight.pie": {
+          "description": "Show a coverage pie chart on repository and directory pages.",
+          "type": "boolean"
         },
         "codecov.decorations.lineCoverage": {
           "description": "Whether to decorate each line with a background color based on its coverage.",

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -24,7 +24,10 @@ describe('Settings', () => {
 
         it('respects the other properties', () => {
             const settings: Settings = {
-                'codecov.graphType': undefined,
+                'codecov.insight.sunburst': false,
+                'codecov.insight.icicle': false,
+                'codecov.insight.tree': false,
+                'codecov.insight.pie': false,
                 'codecov.decorations.lineCoverage': false,
                 'codecov.decorations.lineHitCounts': true,
                 'codecov.showCoverage': true,
@@ -45,7 +48,10 @@ describe('Settings', () => {
 
         it('applies defaults for the other properties', () => {
             const settings: Settings = {
-                'codecov.graphType': undefined,
+                'codecov.insight.tree': false,
+                'codecov.insight.icicle': false,
+                'codecov.insight.sunburst': false,
+                'codecov.insight.pie': false,
                 'codecov.decorations.lineCoverage': false,
                 'codecov.decorations.lineHitCounts': false,
                 'codecov.showCoverage': true,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,14 +3,20 @@ import { map } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import { Service } from './api'
 
+export interface InsightSettings {
+    ['codecov.insight.icicle']: boolean
+    ['codecov.insight.tree']: boolean
+    ['codecov.insight.sunburst']: boolean
+    ['codecov.insight.pie']: boolean
+}
+
 /**
  * The resolved and normalized settings for this extension, the result of calling resolveSettings on a raw settings
  * value.
  *
  * See the configuration JSON Schema in extension.json for the canonical documentation on these properties.
  */
-export interface Settings {
-    ['codecov.graphType']?: 'icicle' | 'tree' | 'sunburst'
+export interface Settings extends InsightSettings {
     ['codecov.showCoverage']: boolean
     ['codecov.decorations.lineCoverage']: boolean
     ['codecov.decorations.lineHitCounts']: boolean
@@ -20,7 +26,10 @@ export interface Settings {
 /** Returns a copy of the extension settings with values normalized and defaults applied. */
 export function resolveSettings(raw: Partial<Settings>): Settings {
     return {
-        ['codecov.graphType']: raw['codecov.graphType'] || undefined,
+        ['codecov.insight.icicle']: raw['codecov.insight.icicle'] || false,
+        ['codecov.insight.tree']: raw['codecov.insight.tree'] || false,
+        ['codecov.insight.sunburst']: raw['codecov.insight.sunburst'] || false,
+        ['codecov.insight.pie']: raw['codecov.insight.pie'] || false,
         ['codecov.showCoverage']: raw['codecov.showCoverage'] !== false,
         ['codecov.decorations.lineCoverage']: !!raw['codecov.decorations.lineCoverage'],
         ['codecov.decorations.lineHitCounts']: !!raw['codecov.decorations.lineHitCounts'],


### PR DESCRIPTION
Uses the new charting APIs in https://github.com/sourcegraph/sourcegraph/pull/10550 to allow contributing a pie chart of coverage of the current directory.