### PR TITLE
Update extension registry category

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,7 @@
     "url": "https://github.com/codecov/sourcegraph-codecov.git"
   },
   "categories": [
-    "Reports and stats",
-    "External services",
-    "Insights",
-    "Code analysis"
+    "Reports and stats"
   ],
   "tags": [
     "codecov",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "url": "https://github.com/codecov/sourcegraph-codecov.git"
   },
   "categories": [
-    "External services",
     "Reports and stats",
+    "External services",
     "Insights",
     "Code analysis"
   ],


### PR DESCRIPTION
`sourcegraph/codecov` should primarily be a "reports and stats" extension (Part of [RFC 209](https://docs.google.com/document/d/1I5BMEGp3QuB81AjSzLCQwq_XJV1sXevlU0lpB4O1pj8/))