### PR TITLE
docs: explain why we check for file decoration API

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -222,7 +222,8 @@ export function activate(
         }
     }
 
-    // Experimental: file decorations
+    // Experimental: file decorations. Check if the Sourcegraph instance supports
+    // file decoration providers (minimum Sourcegraph version 3.23)
     if (sourcegraph.app.registerFileDecorationProvider) {
         function createFileDecoration(uri: string, ratio: number, settings: Settings): sourcegraph.FileDecoration {
             const after = {


### PR DESCRIPTION
Help extension authors debug file decoration development in case their instance is pre-3.23 (no need to publish the extension, ofc, and can merge on approval)