### PR TITLE
Remove old instructional video

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 A [Sourcegraph extension](https://docs.sourcegraph.com/extensions) for showing code coverage information from [Codecov](https://codecov.io) on GitHub, Sourcegraph, and other tools.
 
-[**🎥 Demo video**](https://www.youtube.com/watch?v=j1eWBa3rWH8)
-
 [**🗃️ Source code**](https://github.com/codecov/sourcegraph-codecov)
 
 [**➕ Add to Sourcegraph**](https://sourcegraph.com/extensions/sourcegraph/codecov)


### PR DESCRIPTION
The video is completely out of date and doesn't reflect our UI anymore. Unfortunately we don't have a replacement yet so the best course of action might to remove it completely.